### PR TITLE
Netlify CLI seems to want equals signs for args

### DIFF
--- a/jenkins/deploy.sh
+++ b/jenkins/deploy.sh
@@ -5,5 +5,5 @@ set -eo pipefail
 npm run build -k "$WPT_API_KEY"
 
 if [[ -n "$NETLIFY_AUTH_TOKEN" ]]; then
-  netlify deploy --prod --dir dashboard
+  netlify deploy --prod --dir=dashboard
 fi


### PR DESCRIPTION
@alexgibson hopefully this will do it.

Fix #12