### PR TITLE
Add new prod CDN for WMO

### DIFF
--- a/sites/mozorg_cdn_migration.json
+++ b/sites/mozorg_cdn_migration.json
@@ -1,0 +1,12 @@
+{
+    "name": "www_mozorg_moz_works",
+    "location": "ec2-us-west-1:Chrome",
+    "connection": "3GFast",
+    "pages": [
+        "https://www.mozorg.moz.works/en-US/",
+        "https://www.mozorg.moz.works/en-US/firefox/",
+        "https://www.mozorg.moz.works/en-US/firefox/mobile/",
+        "https://www.mozorg.moz.works/en-US/firefox/new/",
+        "https://www.mozorg.moz.works/en-US/firefox/accounts/"
+    ]
+}


### PR DESCRIPTION
I would like to add the new CDN (currently at a temporary domain) to the dashboard so that we can compare it to the current CDN for WMO. @alexgibson it looks to me like this is all that's needed for that to happen. Can you take a look and let me know?